### PR TITLE
Support .cellsignore file at root of synced directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ XGO_BIN?=${GOPATH}/bin/xgo
 
 .PHONY: all dev win xgo
 
-all: clean cli
+all: clean dev
 
 dep:
 	go install github.com/akavel/rsrc@latest

--- a/app/ux/package.json
+++ b/app/ux/package.json
@@ -33,8 +33,8 @@
     "whatwg-fetch": "^3.6.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Extended the syncer to look for a file called .cellsignore at the root of a synced directory. All lines from that file are then included in the existing syncTask ignore filter.